### PR TITLE
feat: add phase3 RL smoke pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ build/
 app/bin/
 packaging/
 requirements-desktop.txt
+
+phase3_rl/generated/
+phase3_rl/runs/

--- a/phase3_rl/README.md
+++ b/phase3_rl/README.md
@@ -1,0 +1,174 @@
+# Crayotter Phase 3 RL Pipeline
+
+[English](./README.md) | [中文](./README_CN.md)
+
+This directory documents the current `verl + Qwen3.5 + Crayotter` Phase 3 RL smoke pipeline, including how the pipeline is wired, which environment assumptions matter, and how to reproduce the current single-GPU smoke run.
+
+## What Is Included
+
+- local scripted rollout validation for Phase 3 fixtures
+- export of Phase 3 data into `verl` JSONL format
+- export of Crayotter tool schemas into native `verl` tool config YAML
+- `CrayotterSubprocessTool` integration for tool execution
+- `CrayotterPhase3ToolAgentLoop` integration for episode reward attachment
+- a conservative single-GPU GRPO smoke launcher based on sglang multi-turn rollout
+
+This is an on-policy GRPO smoke path. It is meant to verify the integration, not to benchmark training throughput.
+
+## Directory Map
+
+- `fixtures/`: Phase 3 fixtures. `local_smoke` is the default smoke case.
+- `generated/`: exported dataset, tool config, and optional validation or rollout dumps.
+- `runs/local/`: local rollout traces and per-episode runtime roots.
+- `runs/verl/`: runtime roots created during `verl` rollouts.
+- `local_env.py`: local Phase 3 rollout loop.
+- `export_verl_phase3_dataset.py`: fixture-to-JSONL export.
+- `generate_verl_tool_config.py`: tool-schema-to-YAML export.
+- `verl_tools.py`: Crayotter tool wrapper for `verl`.
+- `verl_agent_loop.py`: custom Phase 3 tool agent loop registration.
+- `run_verl_phase3_grpo.sh`: smoke-run launcher.
+
+## How The Pipeline Works
+
+1. A fixture defines the task, allowed tools, seeded files, and optional scripted turns.
+2. `prompt_builder.py` turns the fixture into the multi-turn prompt expected by Phase 3.
+3. `generate_verl_tool_config.py` generates a native `verl` tool config YAML.
+4. `verl_tools.py` exposes Crayotter tools through `CrayotterSubprocessTool`.
+5. `verl_agent_loop.py` registers `CrayotterPhase3ToolAgentLoop`, which extends `verl`'s `ToolAgentLoop` and writes episode reward.
+6. `run_verl_phase3_grpo.sh` launches `python3 -m verl.trainer.main_ppo` with `algorithm.adv_estimator=grpo` and the sglang multi-turn config path.
+
+## `verl` Contract In This Repo
+
+This pipeline is built around the vendored checkout under `_vendor/verl`.
+
+- `VERL_DIR` defaults to `$PROJECT_DIR/_vendor/verl`.
+- `RUN_CWD` should point at the same repo root so Hydra can find `verl/trainer/config`.
+- `MODEL_PATH` points to model weights and is independent from `VERL_DIR`.
+- The model does not need to live next to `verl`.
+
+`_vendor/verl` is not a pristine upstream copy. It contains local patches required by the current smoke path, including:
+
+- Qwen3.5 `mRoPE` / `position_ids` handling
+- nested `position_ids` handling in padding and TensorDict selection
+- a safer entropy path in `ray_trainer.py`
+- fallback behavior in `attention_utils.py`
+- dependency pins in `_vendor/verl/requirements_sglang.txt`
+
+If `_vendor/verl` is replaced, those patches must be preserved. A historical duplicate clone at `/root/verl` was removed from the reference server; the recommended setup is to keep a single active `verl` checkout per machine.
+
+## Reference AutoDL Environment
+
+The environment below was inspected on `2026-04-17` and matches the smoke path that was manually validated.
+
+| Item | Reference value |
+| --- | --- |
+| GPU | NVIDIA GeForce RTX 4090 24 GB |
+| Driver | 580.76.05 |
+| CUDA | 13.0 |
+| Base Python | `/root/miniconda3/bin/python` |
+| Working Python | `/root/venvs/verl_q35/bin/python` |
+| Project root | `/root/autodl-tmp/Crayotter-main` |
+| Vendored `verl` | `/root/autodl-tmp/Crayotter-main/_vendor/verl` |
+| Extra Python package root | `/root/autodl-tmp/pylibs` |
+| Historical duplicate clone | `/root/verl` (removed) |
+
+The smoke path worked from `/root/venvs/verl_q35`, not from the `base` conda environment.
+
+## Dependency Files
+
+The RL runtime is not described by a single file.
+
+| File or layer | Role | Notes |
+| --- | --- | --- |
+| repo-root `requirements.txt` | Crayotter app dependencies | Not the full RL runtime. Keep this file in UTF-8 when syncing to Linux. |
+| `_vendor/verl/requirements_sglang.txt` | nearest committed `verl + sglang` dependency spec | Includes the key pins for the smoke path. |
+| live server state | actual working runtime | May also rely on a venv, `PYTHONPATH`, and packages installed into a separate target directory. |
+
+Key pinned entries in `_vendor/verl/requirements_sglang.txt`:
+
+- `transformers==5.5.3`
+- `sglang[all]==0.5.9`
+- `huggingface_hub==1.10.1`
+
+One important gotcha: on the reference server, `sglang` was effectively provided through `/root/autodl-tmp/pylibs`, not through the venv site-packages alone. That means `pip show sglang` may look empty even when imports work.
+
+## Recommended Reproduction Flow
+
+1. Activate the validated Python environment and export the required runtime variables:
+
+```bash
+source /root/venvs/verl_q35/bin/activate
+
+export CUDA_HOME=/usr/local/cuda-13.0
+export OMP_NUM_THREADS=1
+export VLLM_CACHE_ROOT=/root/autodl-tmp/vllm-cache
+export TORCHINDUCTOR_CACHE_DIR=/root/autodl-tmp/vllm-cache/torchinductor
+export SGLANG_DISABLE_CUDNN_CHECK=1
+export PYTHONPATH=/root/autodl-tmp/pylibs:/root/autodl-tmp/Crayotter-main/_vendor/verl:/root/autodl-tmp/Crayotter-main:${PYTHONPATH:-}
+```
+
+2. Verify imports before training:
+
+```bash
+python - <<'PY'
+import torch
+import vllm
+import ray
+import tensordict
+import verl
+import phase3_rl
+print("torch:", torch.__version__)
+print("vllm:", vllm.__version__)
+print("verl import ok")
+print("phase3_rl import ok")
+PY
+```
+
+3. Validate the local scripted smoke path:
+
+```bash
+python -m phase3_rl.run_local_rollout --fixture local_smoke --policy scripted
+```
+
+4. Export the training assets:
+
+```bash
+python -m phase3_rl.export_verl_phase3_dataset --fixtures local_smoke
+python -m phase3_rl.generate_verl_tool_config --fixture local_smoke
+```
+
+5. Launch a short GRPO smoke run:
+
+```bash
+VERL_DIR=/root/autodl-tmp/Crayotter-main/_vendor/verl \
+MODEL_PATH=/root/autodl-tmp/models/Qwen3.5-0.8B \
+EXPERIMENT_NAME=crayotter-phase3-grpo-debug \
+RESUME_MODE=disable \
+TOTAL_TRAINING_STEPS=10 \
+TRAIN_BATCH_SIZE=1 \
+VAL_BATCH_SIZE=1 \
+PPO_MINI_BATCH_SIZE=1 \
+PPO_MICRO_BATCH_SIZE=1 \
+ROLLOUT_N=1 \
+bash /root/autodl-tmp/Crayotter-main/phase3_rl/run_verl_phase3_grpo.sh
+```
+
+The launcher itself already adds `$VERL_DIR:$PROJECT_DIR` to `PYTHONPATH`. The extra `/root/autodl-tmp/pylibs` prefix still needs to be exported externally on the reference server.
+
+## Common Failure Modes
+
+- Wrong Python: `base` may import some packages but still miss the actual RL stack. Use `/root/venvs/verl_q35`.
+- Missing `sglang`: check whether `/root/autodl-tmp/pylibs` is present in `PYTHONPATH`.
+- Wrong `verl`: if more than one checkout exists, keep `_vendor/verl` first in `PYTHONPATH` and set `VERL_DIR` explicitly.
+- `flash-attn` build failures: the validated server ended up using a prebuilt `flash_attn 2.8.3` wheel. Prefer a wheel over source build for `torch 2.11 + cu130`.
+- Model path issues: an earlier download flow used `local_dir_use_symlinks=False` to avoid local model path problems inside `verl`. Prefer real files over a symlink-heavy layout.
+- Environment drift: the live server changed over time. For any run that should be reproducible, record the exact package versions used together.
+
+## Outputs
+
+- local traces: `phase3_rl/runs/local/<fixture>_xxx/`
+- exported dataset: `phase3_rl/generated/phase3_fixtures.jsonl`
+- generated tool config: `phase3_rl/generated/tool_config.yaml`
+- optional validation dumps: `phase3_rl/generated/val_dumps/`
+- optional rollout dumps: `phase3_rl/generated/rollout_dumps/`
+- checkpoints: `_vendor/verl/checkpoints/`

--- a/phase3_rl/README_CN.md
+++ b/phase3_rl/README_CN.md
@@ -1,0 +1,174 @@
+# Crayotter Phase 3 RL Pipeline
+
+[English](./README.md) | [中文](./README_CN.md)
+
+这个目录记录的是当前 `verl + Qwen3.5 + Crayotter` 的 Phase 3 RL smoke pipeline，主要说明这条链路是如何接起来的、依赖哪些环境前提，以及怎样按当前方式复现单卡 smoke run。
+
+## 这个目录提供什么
+
+- 基于 fixture 的本地 scripted rollout 验证
+- 将 Phase 3 任务导出为 `verl` 可读的 JSONL 数据集
+- 将 Crayotter 工具 schema 导出为 `verl` 原生 tool config YAML
+- 通过 `CrayotterSubprocessTool` 接入工具执行
+- 通过 `CrayotterPhase3ToolAgentLoop` 接入 episode reward
+- 基于 sglang multi-turn rollout 的单卡 GRPO smoke 启动脚本
+
+这条链路是 on-policy GRPO smoke path，目标是验证集成是否打通，不是做吞吐或效果 benchmark。
+
+## 目录说明
+
+- `fixtures/`：Phase 3 fixture。默认 smoke case 是 `local_smoke`。
+- `generated/`：导出的数据集、tool config，以及可选的 validation 或 rollout dump。
+- `runs/local/`：本地 rollout trace 和每次 episode 的运行目录。
+- `runs/verl/`：`verl` rollout 过程中创建的运行目录。
+- `local_env.py`：本地 Phase 3 rollout 主循环。
+- `export_verl_phase3_dataset.py`：fixture 到 JSONL 的导出脚本。
+- `generate_verl_tool_config.py`：tool schema 到 YAML 的导出脚本。
+- `verl_tools.py`：Crayotter 工具到 `verl` 工具的包装层。
+- `verl_agent_loop.py`：自定义 Phase 3 tool agent loop 注册。
+- `run_verl_phase3_grpo.sh`：smoke run 启动入口。
+
+## Pipeline 是怎么接起来的
+
+1. fixture 定义任务、允许调用的工具、种子文件和可选 scripted turns。
+2. `prompt_builder.py` 把 fixture 组装成符合 Phase 3 格式的多轮 prompt。
+3. `generate_verl_tool_config.py` 生成 `verl` 原生 tool config YAML。
+4. `verl_tools.py` 通过 `CrayotterSubprocessTool` 把 Crayotter 工具暴露给 `verl`。
+5. `verl_agent_loop.py` 注册 `CrayotterPhase3ToolAgentLoop`，在 `verl` 的 `ToolAgentLoop` 基础上补充 episode reward。
+6. `run_verl_phase3_grpo.sh` 通过 `python3 -m verl.trainer.main_ppo`，配合 `algorithm.adv_estimator=grpo` 和 sglang multi-turn 配置启动训练。
+
+## 仓库里的 `verl` 约定
+
+当前 pipeline 以 `_vendor/verl` 这份 vendored checkout 为准。
+
+- `VERL_DIR` 默认是 `$PROJECT_DIR/_vendor/verl`
+- `RUN_CWD` 应指向同一个 repo root，这样 Hydra 才能找到 `verl/trainer/config`
+- `MODEL_PATH` 单独指向模型权重，和 `VERL_DIR` 没有目录绑定关系
+- 模型不需要和 `verl` 放在同一个目录下
+
+需要特别说明的是，`_vendor/verl` 不是纯上游版本，而是带本地补丁的版本，当前 smoke path 依赖这些修改，主要包括：
+
+- Qwen3.5 的 `mRoPE` / `position_ids` 处理
+- padding 和 TensorDict 选择阶段对 nested `position_ids` 的处理
+- `ray_trainer.py` 中更稳妥的 entropy 路径
+- `attention_utils.py` 中的 fallback 行为
+- `_vendor/verl/requirements_sglang.txt` 中的依赖 pin
+
+如果替换 `_vendor/verl`，这些补丁需要一并保留。参考服务器上曾经有过另一份 `/root/verl` clone，但已经删除；推荐做法是一台机器只保留一份正在使用的 `verl` checkout。
+
+## 参考 AutoDL 环境
+
+下面这套环境是在 `2026-04-17` 实际检查过、并与当前 smoke 路径对应的参考环境。
+
+| 项目 | 参考值 |
+| --- | --- |
+| GPU | NVIDIA GeForce RTX 4090 24 GB |
+| Driver | 580.76.05 |
+| CUDA | 13.0 |
+| base Python | `/root/miniconda3/bin/python` |
+| 实际工作 Python | `/root/venvs/verl_q35/bin/python` |
+| 项目根目录 | `/root/autodl-tmp/Crayotter-main` |
+| vendored `verl` | `/root/autodl-tmp/Crayotter-main/_vendor/verl` |
+| 额外 Python 包目录 | `/root/autodl-tmp/pylibs` |
+| 历史重复 clone | `/root/verl`（已删除） |
+
+这条 smoke 路径是在 `/root/venvs/verl_q35` 里跑通的，不是在 `base` conda 环境里。
+
+## 依赖文件怎么理解
+
+这条 RL 运行时不能只看一个 `requirements.txt`。
+
+| 文件或层级 | 作用 | 说明 |
+| --- | --- | --- |
+| 仓库根目录 `requirements.txt` | Crayotter 主应用依赖 | 不是完整 RL 运行时。同步到 Linux 时建议保持 UTF-8 编码。 |
+| `_vendor/verl/requirements_sglang.txt` | 最接近当前 `verl + sglang` smoke path 的提交内依赖说明 | 这里有当前最关键的 pin。 |
+| 云端 live 环境 | 实际运行时 | 可能同时依赖 venv、`PYTHONPATH` 和单独目录安装的包。 |
+
+`_vendor/verl/requirements_sglang.txt` 里当前最关键的 pin 包括：
+
+- `transformers==5.5.3`
+- `sglang[all]==0.5.9`
+- `huggingface_hub==1.10.1`
+
+一个很容易踩的点是：参考服务器上的 `sglang` 实际上是通过 `/root/autodl-tmp/pylibs` 暴露给 Python 的，不只是 venv site-packages 自己提供。所以 `pip show sglang` 看起来为空，不代表运行时一定缺这个包。
+
+## 推荐复现流程
+
+1. 先激活实际工作环境，并导出运行时变量：
+
+```bash
+source /root/venvs/verl_q35/bin/activate
+
+export CUDA_HOME=/usr/local/cuda-13.0
+export OMP_NUM_THREADS=1
+export VLLM_CACHE_ROOT=/root/autodl-tmp/vllm-cache
+export TORCHINDUCTOR_CACHE_DIR=/root/autodl-tmp/vllm-cache/torchinductor
+export SGLANG_DISABLE_CUDNN_CHECK=1
+export PYTHONPATH=/root/autodl-tmp/pylibs:/root/autodl-tmp/Crayotter-main/_vendor/verl:/root/autodl-tmp/Crayotter-main:${PYTHONPATH:-}
+```
+
+2. 正式训练前先做 import 检查：
+
+```bash
+python - <<'PY'
+import torch
+import vllm
+import ray
+import tensordict
+import verl
+import phase3_rl
+print("torch:", torch.__version__)
+print("vllm:", vllm.__version__)
+print("verl import ok")
+print("phase3_rl import ok")
+PY
+```
+
+3. 先验证本地 scripted smoke 路径：
+
+```bash
+python -m phase3_rl.run_local_rollout --fixture local_smoke --policy scripted
+```
+
+4. 导出训练所需资产：
+
+```bash
+python -m phase3_rl.export_verl_phase3_dataset --fixtures local_smoke
+python -m phase3_rl.generate_verl_tool_config --fixture local_smoke
+```
+
+5. 启动一个短的 GRPO smoke run：
+
+```bash
+VERL_DIR=/root/autodl-tmp/Crayotter-main/_vendor/verl \
+MODEL_PATH=/root/autodl-tmp/models/Qwen3.5-0.8B \
+EXPERIMENT_NAME=crayotter-phase3-grpo-debug \
+RESUME_MODE=disable \
+TOTAL_TRAINING_STEPS=10 \
+TRAIN_BATCH_SIZE=1 \
+VAL_BATCH_SIZE=1 \
+PPO_MINI_BATCH_SIZE=1 \
+PPO_MICRO_BATCH_SIZE=1 \
+ROLLOUT_N=1 \
+bash /root/autodl-tmp/Crayotter-main/phase3_rl/run_verl_phase3_grpo.sh
+```
+
+`run_verl_phase3_grpo.sh` 自己会把 `$VERL_DIR:$PROJECT_DIR` 加进 `PYTHONPATH`，但参考服务器上的 `/root/autodl-tmp/pylibs` 仍然需要你在外层手动 export。
+
+## 常见失败点
+
+- Python 用错：`base` 可能能导入一部分包，但并不是实际跑通 RL 的环境。请使用 `/root/venvs/verl_q35`。
+- `sglang` 缺失：优先检查 `/root/autodl-tmp/pylibs` 是否在 `PYTHONPATH` 里。
+- 导入到错误的 `verl`：如果机器上存在多份 checkout，让 `_vendor/verl` 优先出现在 `PYTHONPATH` 里，并显式设置 `VERL_DIR`。
+- `flash-attn` 源码编译失败：参考服务器最终使用的是预编译 `flash_attn 2.8.3` wheel，优先使用与 `torch 2.11 + cu130` 匹配的 wheel。
+- 模型路径问题：历史下载流程里用过 `local_dir_use_symlinks=False` 来避免本地模型目录在 `verl` 里出路径问题，建议优先使用真实文件而不是复杂软链接。
+- 环境漂移：服务器是长期交互式环境，不要默认 live server 和提交到仓库的 requirement pin 完全一致。需要复现的 run 应单独记录精确版本。
+
+## 输出产物
+
+- 本地 traces：`phase3_rl/runs/local/<fixture>_xxx/`
+- 导出的数据集：`phase3_rl/generated/phase3_fixtures.jsonl`
+- 生成的 tool config：`phase3_rl/generated/tool_config.yaml`
+- 可选 validation dump：`phase3_rl/generated/val_dumps/`
+- 可选 rollout dump：`phase3_rl/generated/rollout_dumps/`
+- checkpoints：`_vendor/verl/checkpoints/`

--- a/phase3_rl/__init__.py
+++ b/phase3_rl/__init__.py
@@ -1,0 +1,25 @@
+"""Phase 3 RL rollout scaffolding for Crayotter."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _bootstrap_import_paths() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    script_root = repo_root / "script"
+    for candidate in (repo_root, script_root):
+        text = str(candidate)
+        if text not in sys.path:
+            sys.path.insert(0, text)
+
+
+_bootstrap_import_paths()
+
+from .fixture import Phase3Fixture, load_fixture
+
+__all__ = [
+    "Phase3Fixture",
+    "load_fixture",
+]

--- a/phase3_rl/export_verl_phase3_dataset.py
+++ b/phase3_rl/export_verl_phase3_dataset.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+
+from .fixture import list_fixtures, load_fixture, materialize_fixture
+from .prompt_builder import build_phase3_messages
+
+
+DEFAULT_AGENT_NAME = "crayotter_phase3_tool_agent"
+
+
+def _build_record(fixture_id: str, index: int, episode_base_dir: str) -> dict:
+    fixture = load_fixture(fixture_id)
+    with tempfile.TemporaryDirectory(prefix=f"crayotter_{fixture.fixture_id}_") as temp_dir:
+        runtime_root = materialize_fixture(fixture, temp_dir)
+        prompt = build_phase3_messages(
+            user_request=fixture.user_request,
+            target_duration_seconds=fixture.target_duration_seconds,
+            editing_blueprint=fixture.editing_blueprint,
+            runtime_root=runtime_root,
+            tool_names=fixture.allowed_tools,
+        )
+
+    tools_kwargs = {
+        tool_name: {
+            "create_kwargs": {
+                "fixture_path": str(fixture.source_path),
+                "episode_base_dir": episode_base_dir,
+            }
+        }
+        for tool_name in fixture.allowed_tools
+    }
+    return {
+        "data_source": "crayotter_phase3",
+        "agent_name": DEFAULT_AGENT_NAME,
+        "prompt": prompt,
+        "ability": "video_editing",
+        "reward_model": {"style": "rule", "ground_truth": fixture.fixture_id},
+        "target_duration_seconds": fixture.target_duration_seconds,
+        "extra_info": {
+            "index": index,
+            "fixture_id": fixture.fixture_id,
+            "need_tools_kwargs": True,
+            "tools_kwargs": tools_kwargs,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export Crayotter Phase 3 fixtures as a verl-friendly dataset.")
+    parser.add_argument(
+        "--fixtures",
+        nargs="*",
+        default=[],
+        help="Fixture ids. Defaults to all fixtures under phase3_rl/fixtures.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(Path(__file__).resolve().parent / "generated" / "phase3_fixtures.jsonl"),
+    )
+    parser.add_argument(
+        "--episode-base-dir",
+        default=str(Path(__file__).resolve().parent / "runs" / "verl"),
+        help="Base dir passed to tool create_kwargs in verl rollouts.",
+    )
+    args = parser.parse_args()
+
+    fixture_ids = args.fixtures or list_fixtures()
+    records = [_build_record(fixture_id, idx, args.episode_base_dir) for idx, fixture_id in enumerate(fixture_ids)]
+
+    output_path = Path(args.output).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    print(
+        json.dumps(
+            {
+                "output": str(output_path),
+                "record_count": len(records),
+                "agent_name": DEFAULT_AGENT_NAME,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/phase3_rl/fixture.py
+++ b/phase3_rl/fixture.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+@dataclass(slots=True)
+class SeedFile:
+    source: str = ""
+    target: str = ""
+    generator: str = ""
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ScriptedToolCall:
+    tool_name: str
+    arguments: dict[str, Any]
+
+
+@dataclass(slots=True)
+class ScriptedTurn:
+    assistant_content: str = ""
+    tool_calls: list[ScriptedToolCall] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class Phase3Fixture:
+    fixture_id: str
+    description: str
+    user_request: str
+    target_duration_seconds: float
+    editing_blueprint: str = ""
+    allowed_tools: list[str] = field(default_factory=list)
+    runtime_seed: list[SeedFile] = field(default_factory=list)
+    scripted_turns: list[ScriptedTurn] = field(default_factory=list)
+    source_path: Path | None = None
+
+
+def fixture_dir(fixture_id: str) -> Path:
+    return _project_root() / "phase3_rl" / "fixtures" / fixture_id
+
+
+def resolve_fixture_path(identifier_or_path: str | Path) -> Path:
+    raw = Path(identifier_or_path)
+    if raw.exists():
+        return raw.resolve()
+
+    candidate = fixture_dir(str(identifier_or_path)) / "fixture.json"
+    if candidate.exists():
+        return candidate.resolve()
+
+    raise FileNotFoundError(f"Fixture not found: {identifier_or_path}")
+
+
+def _parse_scripted_turn(raw: dict[str, Any]) -> ScriptedTurn:
+    calls = [
+        ScriptedToolCall(
+            tool_name=str(item["tool_name"]),
+            arguments=dict(item.get("arguments", {})),
+        )
+        for item in raw.get("tool_calls", [])
+    ]
+    return ScriptedTurn(
+        assistant_content=str(raw.get("assistant_content", "")),
+        tool_calls=calls,
+    )
+
+
+def load_fixture(identifier_or_path: str | Path) -> Phase3Fixture:
+    path = resolve_fixture_path(identifier_or_path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    return Phase3Fixture(
+        fixture_id=str(payload["fixture_id"]),
+        description=str(payload.get("description", "")),
+        user_request=str(payload["user_request"]),
+        target_duration_seconds=float(payload.get("target_duration_seconds", 0.0) or 0.0),
+        editing_blueprint=str(payload.get("editing_blueprint", "")),
+        allowed_tools=[str(item) for item in payload.get("allowed_tools", [])],
+        runtime_seed=[
+            SeedFile(
+                source=str(item.get("source", "")),
+                target=str(item["target"]),
+                generator=str(item.get("generator", "")),
+                options=dict(item.get("options", {})),
+            )
+            for item in payload.get("runtime_seed", [])
+        ],
+        scripted_turns=[_parse_scripted_turn(item) for item in payload.get("scripted_turns", [])],
+        source_path=path,
+    )
+
+
+def list_fixtures() -> list[str]:
+    root = _project_root() / "phase3_rl" / "fixtures"
+    if not root.exists():
+        return []
+    return sorted([item.name for item in root.iterdir() if (item / "fixture.json").exists()])
+
+
+def build_episode_root(base_dir: str | Path, fixture_id: str) -> Path:
+    base = Path(base_dir).resolve()
+    base.mkdir(parents=True, exist_ok=True)
+    safe_id = "".join(ch if ch.isalnum() or ch in {"_", "-"} else "_" for ch in fixture_id).strip("_") or "fixture"
+    existing = sorted(base.glob(f"{safe_id}_*"))
+    next_index = len(existing) + 1
+    root = base / f"{safe_id}_{next_index:03d}"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def materialize_fixture(
+    fixture: Phase3Fixture,
+    episode_root: str | Path,
+    *,
+    project_root: str | Path | None = None,
+) -> Path:
+    repo_root = Path(project_root).resolve() if project_root else _project_root()
+    root = Path(episode_root).resolve()
+    (root / "temp").mkdir(parents=True, exist_ok=True)
+    (root / "user_temp").mkdir(parents=True, exist_ok=True)
+    (root / "memory_experience").mkdir(parents=True, exist_ok=True)
+    (root / "logs").mkdir(parents=True, exist_ok=True)
+
+    for seed in fixture.runtime_seed:
+        dst = (root / seed.target).resolve()
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if seed.generator:
+            _materialize_generated_seed(dst, seed.generator, seed.options)
+            continue
+
+        src = (repo_root / seed.source).resolve()
+        shutil.copy2(src, dst)
+
+    source_memory = repo_root / "memory_experience" / "latest_skills.md"
+    target_memory = root / "memory_experience" / "latest_skills.md"
+    if source_memory.exists() and not target_memory.exists():
+        shutil.copy2(source_memory, target_memory)
+
+    meta_path = root / "fixture_meta.json"
+    meta_path.write_text(
+        json.dumps(
+            {
+                "fixture_id": fixture.fixture_id,
+                "description": fixture.description,
+                "source_fixture": str(fixture.source_path) if fixture.source_path else "",
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+def _materialize_generated_seed(target: Path, generator: str, options: dict[str, Any]) -> None:
+    if generator == "synthetic_video":
+        _generate_synthetic_video(target, options)
+        return
+    raise ValueError(f"Unsupported runtime seed generator: {generator}")
+
+
+def _generate_synthetic_video(target: Path, options: dict[str, Any]) -> None:
+    from moviepy import ColorClip
+
+    duration = float(options.get("duration_seconds", 6.0) or 6.0)
+    width = int(options.get("width", 640) or 640)
+    height = int(options.get("height", 360) or 360)
+    fps = int(options.get("fps", 24) or 24)
+    color = options.get("color", [40, 120, 220])
+    if not isinstance(color, list) or len(color) != 3:
+        color = [40, 120, 220]
+
+    clip = ColorClip(
+        size=(max(16, width), max(16, height)),
+        color=tuple(int(max(0, min(255, item))) for item in color),
+        duration=max(0.5, duration),
+    )
+    try:
+        clip.write_videofile(
+            str(target),
+            fps=max(1, fps),
+            codec="libx264",
+            audio=False,
+            logger=None,
+        )
+    finally:
+        clip.close()

--- a/phase3_rl/fixtures/local_smoke/demo_source_analysis.json
+++ b/phase3_rl/fixtures/local_smoke/demo_source_analysis.json
@@ -1,0 +1,52 @@
+{
+  "source_video": "demo_source.mp4",
+  "analysis_video": "demo_source.mp4",
+  "analysis_goal": "本地 smoke test 分析样例",
+  "video_url_used": "",
+  "audio_url_used": "",
+  "segments": [
+    {
+      "start": 0.0,
+      "end": 2.0,
+      "semantic_text": "稳定横屏演示画面，可作为开场和主体片段。"
+    },
+    {
+      "start": 2.0,
+      "end": 4.0,
+      "semantic_text": "素材内容连续，适合保留为中段主体。"
+    },
+    {
+      "start": 4.0,
+      "end": 6.0,
+      "semantic_text": "尾段节奏平稳，适合作为收束镜头。"
+    }
+  ],
+  "semantic_segments": [
+    {
+      "start": 0.0,
+      "end": 2.0,
+      "duration": 2.0,
+      "semantic_text": "稳定横屏演示画面，可作为开场和主体片段。"
+    },
+    {
+      "start": 2.0,
+      "end": 4.0,
+      "duration": 2.0,
+      "semantic_text": "素材内容连续，适合保留为中段主体。"
+    },
+    {
+      "start": 4.0,
+      "end": 6.0,
+      "duration": 2.0,
+      "semantic_text": "尾段节奏平稳，适合作为收束镜头。"
+    }
+  ],
+  "semantic_index": {
+    "index_version": 2,
+    "segment_count": 3,
+    "retrieval_mode": "text",
+    "updated_at": "2026-04-12T00:00:00"
+  },
+  "analysis_text": "t=0.0s-2.0s: 稳定横屏演示画面，可作为开场和主体片段。\n\nt=2.0s-4.0s: 素材内容连续，适合保留为中段主体。\n\nt=4.0s-6.0s: 尾段节奏平稳，适合作为收束镜头。",
+  "saved_at": "2026-04-12T00:00:00"
+}

--- a/phase3_rl/fixtures/local_smoke/fixture.json
+++ b/phase3_rl/fixtures/local_smoke/fixture.json
@@ -1,0 +1,90 @@
+{
+  "fixture_id": "local_smoke",
+  "description": "Self-contained Phase 3 smoke test with a generated demo video and scripted tool trajectory.",
+  "user_request": "请把现有素材裁成一个 3 秒左右的简短演示视频，保持横屏，最后导出成片。",
+  "target_duration_seconds": 3.0,
+  "editing_blueprint": "从已有主素材中截取 0.5s 到 3.5s 的稳定片段，先检查原始时长，再裁剪，再检查裁剪结果，最后导出为 720p 成片。",
+  "allowed_tools": [
+    "inspect_video_duration",
+    "cut_video",
+    "export_video"
+  ],
+  "runtime_seed": [
+    {
+      "generator": "synthetic_video",
+      "target": "temp/demo_source.mp4",
+      "options": {
+        "duration_seconds": 6.0,
+        "width": 640,
+        "height": 360,
+        "fps": 24,
+        "color": [42, 128, 198]
+      }
+    },
+    {
+      "source": "phase3_rl/fixtures/local_smoke/demo_source_analysis.json",
+      "target": "temp/demo_source_analysis.json"
+    }
+  ],
+  "scripted_turns": [
+    {
+      "assistant_content": "先确认源素材的时长，再按目标截出 3 秒内容，最后导出成片。",
+      "tool_calls": [
+        {
+          "tool_name": "inspect_video_duration",
+          "arguments": {
+            "video_path": "demo_source.mp4"
+          }
+        }
+      ]
+    },
+    {
+      "assistant_content": "源素材可用，开始裁出核心片段。",
+      "tool_calls": [
+        {
+          "tool_name": "cut_video",
+          "arguments": {
+            "input_path": "demo_source.mp4",
+            "start_time": 0.5,
+            "end_time": 3.5,
+            "output_name": "smoke_clip"
+          }
+        }
+      ]
+    },
+    {
+      "assistant_content": "先复核裁剪结果，再执行最终导出。",
+      "tool_calls": [
+        {
+          "tool_name": "inspect_video_duration",
+          "arguments": {
+            "video_path": "smoke_clip.mp4"
+          }
+        },
+        {
+          "tool_name": "export_video",
+          "arguments": {
+            "input_path": "smoke_clip.mp4",
+            "output_name": "smoke_final",
+            "resolution": "720p"
+          }
+        }
+      ]
+    },
+    {
+      "assistant_content": "成片已经导出并完成基础时长校验，本轮 Phase 3 演示结束。",
+      "tool_calls": [
+        {
+          "tool_name": "inspect_video_duration",
+          "arguments": {
+            "video_path": "smoke_final.mp4"
+          }
+        }
+      ]
+    },
+    {
+      "assistant_content": "已完成裁剪、导出与校验，最终视频位于工作目录中。",
+      "tool_calls": []
+    }
+  ]
+}

--- a/phase3_rl/generate_verl_tool_config.py
+++ b/phase3_rl/generate_verl_tool_config.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import yaml
+
+from .fixture import load_fixture
+from .tool_catalog import get_openai_tool_schemas, get_phase3_tool_names
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate a verl native tool config from Crayotter tool schemas.")
+    parser.add_argument("--fixture", default="", help="Optional fixture id to use fixture.allowed_tools.")
+    parser.add_argument("--output", default=str(Path(__file__).resolve().parent / "generated" / "tool_config.yaml"))
+    args = parser.parse_args()
+
+    if args.fixture:
+        tool_names = load_fixture(args.fixture).allowed_tools
+    else:
+        tool_names = get_phase3_tool_names()
+
+    schemas = get_openai_tool_schemas(tool_names)
+    payload = {"tools": []}
+    for schema in schemas:
+        payload["tools"].append(
+            {
+                "class_name": "phase3_rl.verl_tools.CrayotterSubprocessTool",
+                "config": {
+                    "type": "native",
+                    "tool_name": schema["function"]["name"],
+                },
+                "tool_schema": schema,
+            }
+        )
+
+    output_path = Path(args.output).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(yaml.safe_dump(payload, allow_unicode=True, sort_keys=False), encoding="utf-8")
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/phase3_rl/local_env.py
+++ b/phase3_rl/local_env.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .fixture import Phase3Fixture, build_episode_root, materialize_fixture
+from .policies import PolicyResponse
+from .prompt_builder import build_phase3_messages
+from .reward import compute_episode_reward, compute_step_reward
+from .tool_catalog import get_openai_tool_schemas, get_phase3_tool_names
+from .tool_runtime import ToolExecutionResult, execute_tool_subprocess, load_api_config_from_env
+
+
+class Phase3RolloutEnv:
+    def __init__(
+        self,
+        *,
+        fixture: Phase3Fixture,
+        policy: Any,
+        episode_base_dir: str | Path,
+        python_executable: str | None = None,
+        tool_timeout_seconds: int = 900,
+        api_config: dict[str, str] | None = None,
+    ) -> None:
+        self.fixture = fixture
+        self.policy = policy
+        self.episode_root = build_episode_root(episode_base_dir, fixture.fixture_id)
+        materialize_fixture(fixture, self.episode_root)
+        self.tool_names = fixture.allowed_tools or get_phase3_tool_names()
+        self.tool_schemas = get_openai_tool_schemas(self.tool_names)
+        self.messages = build_phase3_messages(
+            user_request=fixture.user_request,
+            target_duration_seconds=fixture.target_duration_seconds,
+            editing_blueprint=fixture.editing_blueprint,
+            runtime_root=self.episode_root,
+            tool_names=self.tool_names,
+        )
+        self.python_executable = python_executable
+        self.tool_timeout_seconds = tool_timeout_seconds
+        self.api_config = api_config or load_api_config_from_env()
+        self.tool_events: list[dict[str, Any]] = []
+        self.turns: list[dict[str, Any]] = []
+        self.final_output = ""
+
+    def _tool_message(self, tool_call_id: str, content: str) -> dict[str, Any]:
+        return {
+            "role": "tool",
+            "tool_call_id": tool_call_id,
+            "content": content,
+        }
+
+    def _assistant_message(self, response: PolicyResponse) -> dict[str, Any]:
+        message: dict[str, Any] = {
+            "role": "assistant",
+            "content": response.assistant_content,
+        }
+        if response.tool_calls:
+            message["tool_calls"] = response.tool_calls
+        return message
+
+    def _record_tool_event(
+        self,
+        *,
+        tool_name: str,
+        arguments: dict[str, Any],
+        execution: ToolExecutionResult,
+        tool_call_id: str,
+    ) -> dict[str, Any]:
+        reward = compute_step_reward(tool_name=tool_name, execution=execution, prior_events=self.tool_events)
+        event = {
+            "tool_name": tool_name,
+            "tool_call_id": tool_call_id,
+            "arguments": arguments,
+            "success": execution.success,
+            "raw_result": execution.raw_result,
+            "parsed_result": execution.parsed_result,
+            "output_paths": execution.output_paths,
+            "duration_seconds": execution.duration_seconds,
+            "returncode": execution.returncode,
+            "stdout_tail": execution.stdout[-1200:],
+            "stderr_tail": execution.stderr[-1200:],
+            "signature": f"{tool_name}:{json.dumps(arguments, ensure_ascii=False, sort_keys=True)}",
+            "step_reward": reward.total,
+            "step_reward_components": reward.components,
+        }
+        self.tool_events.append(event)
+        return event
+
+    def run(self, max_turns: int = 20) -> dict[str, Any]:
+        for turn_index in range(max_turns):
+            response: PolicyResponse = self.policy.generate(self.messages, self.tool_schemas)
+            assistant_message = self._assistant_message(response)
+            self.messages.append(assistant_message)
+
+            turn_record: dict[str, Any] = {
+                "turn_index": turn_index,
+                "assistant_content": response.assistant_content,
+                "tool_calls": [],
+            }
+
+            if not response.tool_calls:
+                self.final_output = response.assistant_content.strip()
+                self.turns.append(turn_record)
+                break
+
+            for call in response.tool_calls:
+                tool_name = str(call["function"]["name"])
+                arguments = json.loads(call["function"]["arguments"])
+                execution = execute_tool_subprocess(
+                    tool_name=tool_name,
+                    arguments=arguments,
+                    runtime_root=self.episode_root,
+                    api_config=self.api_config,
+                    python_executable=self.python_executable,
+                    timeout_seconds=self.tool_timeout_seconds,
+                )
+                event = self._record_tool_event(
+                    tool_name=tool_name,
+                    arguments=arguments,
+                    execution=execution,
+                    tool_call_id=str(call["id"]),
+                )
+                turn_record["tool_calls"].append(event)
+                self.messages.append(self._tool_message(str(call["id"]), execution.raw_result))
+
+            self.turns.append(turn_record)
+        else:
+            self.final_output = self.final_output or "Episode stopped because max_turns was reached."
+
+        reward_summary = compute_episode_reward(
+            tool_events=self.tool_events,
+            target_duration_seconds=self.fixture.target_duration_seconds,
+            final_output=self.final_output,
+        )
+        trace = {
+            "fixture_id": self.fixture.fixture_id,
+            "episode_root": str(self.episode_root),
+            "tool_names": self.tool_names,
+            "turns": self.turns,
+            "tool_events": self.tool_events,
+            "final_output": self.final_output,
+            "reward_summary": reward_summary,
+        }
+
+        trace_path = self.episode_root / "phase3_episode_trace.json"
+        trace_path.write_text(json.dumps(trace, ensure_ascii=False, indent=2), encoding="utf-8")
+
+        jsonl_path = self.episode_root / "phase3_tool_events.jsonl"
+        with jsonl_path.open("w", encoding="utf-8") as handle:
+            for event in self.tool_events:
+                handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+        transcript_path = self.episode_root / "phase3_messages.json"
+        transcript_path.write_text(json.dumps(self.messages, ensure_ascii=False, indent=2), encoding="utf-8")
+
+        return {
+            "episode_root": str(self.episode_root),
+            "trace_path": str(trace_path),
+            "tool_events_path": str(jsonl_path),
+            "messages_path": str(transcript_path),
+            "reward_summary": reward_summary,
+            "final_output": self.final_output,
+        }

--- a/phase3_rl/policies.py
+++ b/phase3_rl/policies.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+from openai import OpenAI
+
+
+@dataclass(slots=True)
+class PolicyResponse:
+    assistant_content: str
+    tool_calls: list[dict[str, Any]]
+    raw_response: dict[str, Any] | None = None
+
+
+class ScriptedPolicy:
+    def __init__(self, scripted_turns: list[Any]) -> None:
+        self._turns = list(scripted_turns)
+        self._cursor = 0
+
+    def generate(self, messages: list[dict[str, Any]], tool_schemas: list[dict[str, Any]]) -> PolicyResponse:
+        if self._cursor >= len(self._turns):
+            return PolicyResponse(
+                assistant_content="本轮 scripted policy 已经没有额外动作，结束执行。",
+                tool_calls=[],
+            )
+
+        turn = self._turns[self._cursor]
+        self._cursor += 1
+        tool_calls: list[dict[str, Any]] = []
+        for call in turn.tool_calls:
+            tool_calls.append(
+                {
+                    "id": f"call_{uuid4().hex}",
+                    "type": "function",
+                    "function": {
+                        "name": call.tool_name,
+                        "arguments": json.dumps(call.arguments, ensure_ascii=False),
+                    },
+                }
+            )
+        return PolicyResponse(
+            assistant_content=turn.assistant_content,
+            tool_calls=tool_calls,
+        )
+
+
+class OpenAIToolPolicy:
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str,
+        model_name: str,
+        temperature: float = 0.2,
+        max_tokens: int = 1800,
+    ) -> None:
+        if not api_key:
+            raise ValueError("OpenAIToolPolicy requires a non-empty api_key.")
+        if not model_name:
+            raise ValueError("OpenAIToolPolicy requires a non-empty model_name.")
+        self.client = OpenAI(api_key=api_key, base_url=base_url or None)
+        self.model_name = model_name
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+
+    def generate(self, messages: list[dict[str, Any]], tool_schemas: list[dict[str, Any]]) -> PolicyResponse:
+        response = self.client.chat.completions.create(
+            model=self.model_name,
+            messages=messages,
+            tools=tool_schemas,
+            tool_choice="auto",
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+        )
+        choice = response.choices[0]
+        message = choice.message
+        content = message.content or ""
+        tool_calls: list[dict[str, Any]] = []
+        for tool_call in getattr(message, "tool_calls", []) or []:
+            tool_calls.append(
+                {
+                    "id": getattr(tool_call, "id", None) or f"call_{uuid4().hex}",
+                    "type": "function",
+                    "function": {
+                        "name": tool_call.function.name,
+                        "arguments": tool_call.function.arguments,
+                    },
+                }
+            )
+        return PolicyResponse(
+            assistant_content=content,
+            tool_calls=tool_calls,
+            raw_response=response.model_dump() if hasattr(response, "model_dump") else None,
+        )

--- a/phase3_rl/prompt_builder.py
+++ b/phase3_rl/prompt_builder.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from script import graph as graph_module
+
+
+def _read_text(path: Path, default: str = "") -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception:
+        return default
+
+
+def _workspace_snapshot(root: Path, relative_dir: str, max_files: int = 30) -> str:
+    base = root / relative_dir
+    if not base.exists():
+        return f"({relative_dir} 不存在)"
+    files = [item for item in base.rglob("*") if item.is_file()]
+    if not files:
+        return f"({relative_dir} 为空)"
+    files = sorted(files, key=lambda item: item.stat().st_mtime, reverse=True)[:max_files]
+    rows: list[str] = []
+    for item in files:
+        rel = item.relative_to(base)
+        size_mb = item.stat().st_size / (1024 * 1024)
+        rows.append(f"- {rel} ({size_mb:.1f}MB)")
+    return "\n".join(rows)
+
+
+def _analysis_context(root: Path, max_files: int = 12, max_chars_per_file: int = 4000) -> str:
+    candidates = sorted(
+        (list((root / "temp").glob("*_analysis.json")) + list((root / "user_temp").glob("*_analysis.json"))),
+        key=lambda item: item.stat().st_mtime,
+        reverse=True,
+    )
+    if not candidates:
+        return "(无分析数据)"
+
+    blocks: list[str] = []
+    for item in candidates[:max_files]:
+        try:
+            payload = json.loads(item.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        source_video = str(payload.get("source_video", "")) or item.stem.replace("_analysis", "")
+        analysis_text = str(payload.get("analysis_text", "")).strip()
+        segments = payload.get("segments", [])
+        segment_preview: list[str] = []
+        if isinstance(segments, list):
+            for seg in segments[:8]:
+                if not isinstance(seg, dict):
+                    continue
+                try:
+                    start = float(seg.get("start", 0.0))
+                    end = float(seg.get("end", 0.0))
+                except Exception:
+                    continue
+                semantic = str(seg.get("semantic_text", "") or seg.get("description", "")).strip()
+                preview = f"t={start:.1f}s-{end:.1f}s"
+                if semantic:
+                    preview += f": {semantic[:120]}"
+                segment_preview.append(preview)
+        block = [f"### 源视频: {source_video}", f"- 分析文件: {item.name}"]
+        if segment_preview:
+            block.append("- 片段摘要:")
+            block.extend([f"  {row}" for row in segment_preview])
+        if analysis_text:
+            block.append(f"- 分析正文:\n{analysis_text[:max_chars_per_file]}")
+        blocks.append("\n".join(block))
+    return "\n\n".join(blocks) if blocks else "(无分析数据)"
+
+
+def build_phase3_messages(
+    *,
+    user_request: str,
+    target_duration_seconds: float,
+    editing_blueprint: str,
+    runtime_root: str | Path,
+    tool_names: list[str],
+) -> list[dict[str, str]]:
+    root = Path(runtime_root).resolve()
+    system_prompt = graph_module.REACT_EDITOR_PROMPT.format(
+        workspace=root / "temp",
+        user_workspace=root / "user_temp",
+        memory_experience=root / "memory_experience",
+    )
+
+    memory_text = _read_text(root / "memory_experience" / "latest_skills.md", "(无历史经验)")
+    user_parts = [
+        f"## 用户需求\n{user_request}",
+        f"\n## 目标时长\n{target_duration_seconds:.1f} 秒",
+    ]
+    if editing_blueprint.strip():
+        user_parts.append(f"\n## 剪辑蓝图\n{editing_blueprint.strip()}")
+    user_parts.extend(
+        [
+            f"\n## 已有素材分析数据\n{_analysis_context(root)}",
+            f"\n## 当前工作目录文件\n{_workspace_snapshot(root, 'temp')}",
+            f"\n## 用户素材目录文件\n{_workspace_snapshot(root, 'user_temp')}",
+            f"\n## 历史案例经验（仅供参考）\n{memory_text[:8000]}",
+            f"\n## 本轮允许调用的工具\n{', '.join(tool_names)}",
+            "\n## 开始执行\n"
+            "请先给出简短创作思路，然后再基于现有分析数据进行工具调用。"
+            "如果你认为当前素材已经足够，就直接执行剪辑；不要联网搜索。",
+        ]
+    )
+
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": "\n".join(user_parts)},
+    ]

--- a/phase3_rl/reward.py
+++ b/phase3_rl/reward.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from .tool_runtime import ToolExecutionResult
+
+
+@dataclass(slots=True)
+class StepReward:
+    total: float
+    components: dict[str, float]
+
+
+def _canonical_args(arguments: dict[str, Any]) -> str:
+    try:
+        return json.dumps(arguments, ensure_ascii=False, sort_keys=True)
+    except Exception:
+        return str(arguments)
+
+
+def compute_step_reward(
+    *,
+    tool_name: str,
+    execution: ToolExecutionResult,
+    prior_events: list[dict[str, Any]],
+) -> StepReward:
+    components: dict[str, float] = {
+        "tool_success": 0.6 if execution.success else -0.8,
+        "artifact_bonus": 0.1 if execution.output_paths else 0.0,
+        "returncode_penalty": -0.1 if execution.returncode not in (0, 2) else 0.0,
+        "repeat_penalty": 0.0,
+        "order_bonus": 0.0,
+    }
+
+    signature = f"{tool_name}:{_canonical_args(execution.arguments)}"
+    if prior_events:
+        last = prior_events[-1]
+        if signature == last.get("signature"):
+            components["repeat_penalty"] = -0.2
+
+    seen_tools = {str(item.get("tool_name")) for item in prior_events}
+    if tool_name == "export_video":
+        if "inspect_video_duration" in seen_tools:
+            components["order_bonus"] += 0.15
+        else:
+            components["order_bonus"] -= 0.15
+    if tool_name == "add_narration_segments":
+        if "validate_narration_timeline" in seen_tools:
+            components["order_bonus"] += 0.2
+        else:
+            components["order_bonus"] -= 0.4
+    if tool_name == "merge_videos":
+        cut_count = sum(1 for item in prior_events if item.get("tool_name") in {"cut_video", "batch_cut_video"})
+        if cut_count >= 2:
+            components["order_bonus"] += 0.1
+        elif cut_count == 0:
+            components["order_bonus"] -= 0.1
+
+    total = round(sum(components.values()), 4)
+    return StepReward(total=total, components=components)
+
+
+def compute_episode_reward(
+    *,
+    tool_events: list[dict[str, Any]],
+    target_duration_seconds: float,
+    final_output: str,
+) -> dict[str, Any]:
+    step_total = round(sum(float(item.get("step_reward", 0.0)) for item in tool_events), 4)
+
+    export_events = [item for item in tool_events if item.get("tool_name") == "export_video" and item.get("success")]
+    export_bonus = 1.0 if export_events else 0.0
+
+    final_duration = None
+    for item in reversed(tool_events):
+        duration = item.get("duration_seconds")
+        if isinstance(duration, (int, float)) and duration > 0:
+            final_duration = float(duration)
+            break
+
+    duration_reward = 0.0
+    duration_error_ratio = None
+    if final_duration is not None and target_duration_seconds > 0:
+        duration_error_ratio = abs(final_duration - target_duration_seconds) / max(target_duration_seconds, 1.0)
+        duration_reward = max(-0.5, round(0.8 - duration_error_ratio, 4))
+
+    completion_bonus = 0.3 if final_output.strip() else 0.0
+    efficiency_penalty = -0.02 * max(0, len(tool_events) - 6)
+
+    total = round(step_total + export_bonus + duration_reward + completion_bonus + efficiency_penalty, 4)
+    return {
+        "total_reward": total,
+        "step_total": step_total,
+        "export_bonus": export_bonus,
+        "duration_reward": duration_reward,
+        "completion_bonus": completion_bonus,
+        "efficiency_penalty": round(efficiency_penalty, 4),
+        "final_duration_seconds": final_duration,
+        "duration_error_ratio": duration_error_ratio,
+    }

--- a/phase3_rl/run_local_rollout.py
+++ b/phase3_rl/run_local_rollout.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .fixture import list_fixtures, load_fixture
+from .local_env import Phase3RolloutEnv
+from .policies import OpenAIToolPolicy, ScriptedPolicy
+from .tool_runtime import load_api_config_from_env
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a local Phase 3 rollout with reward and trace dump.")
+    parser.add_argument("--fixture", default="local_smoke", help="Fixture id or absolute path to fixture.json")
+    parser.add_argument(
+        "--policy",
+        choices=("scripted", "openai"),
+        default="scripted",
+        help="Use the fixture scripted policy or a real OpenAI-compatible model.",
+    )
+    parser.add_argument(
+        "--episode-base-dir",
+        default=str(Path(__file__).resolve().parent / "runs" / "local"),
+        help="Directory that stores per-episode runtime roots.",
+    )
+    parser.add_argument("--max-turns", type=int, default=20)
+    parser.add_argument("--tool-timeout-seconds", type=int, default=900)
+    parser.add_argument("--api-key", default="")
+    parser.add_argument("--base-url", default="")
+    parser.add_argument("--model-name", default="")
+    parser.add_argument("--temperature", type=float, default=0.2)
+    parser.add_argument("--max-tokens", type=int, default=1800)
+    parser.add_argument("--list-fixtures", action="store_true")
+    return parser.parse_args()
+
+
+def build_policy(args: argparse.Namespace, fixture) -> object:
+    if args.policy == "scripted":
+        return ScriptedPolicy(fixture.scripted_turns)
+
+    api_config = load_api_config_from_env()
+    api_key = args.api_key or api_config["api_key"]
+    base_url = args.base_url or api_config["base_url"]
+    model_name = args.model_name or api_config["model_name"]
+    return OpenAIToolPolicy(
+        api_key=api_key,
+        base_url=base_url,
+        model_name=model_name,
+        temperature=args.temperature,
+        max_tokens=args.max_tokens,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    if args.list_fixtures:
+        print(json.dumps({"fixtures": list_fixtures()}, ensure_ascii=False, indent=2))
+        return 0
+
+    fixture = load_fixture(args.fixture)
+    policy = build_policy(args, fixture)
+    env = Phase3RolloutEnv(
+        fixture=fixture,
+        policy=policy,
+        episode_base_dir=args.episode_base_dir,
+        python_executable=sys.executable,
+        tool_timeout_seconds=args.tool_timeout_seconds,
+    )
+    result = env.run(max_turns=args.max_turns)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/phase3_rl/run_verl_phase3_grpo.sh
+++ b/phase3_rl/run_verl_phase3_grpo.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERL_DIR="${VERL_DIR:-$PROJECT_DIR/_vendor/verl}"
+CONFIG_PATH="${CONFIG_PATH:-$VERL_DIR/examples/sglang_multiturn/config}"
+RUN_CWD="${RUN_CWD:-$VERL_DIR}"
+
+TRAIN_FILE="${TRAIN_FILE:-$PROJECT_DIR/phase3_rl/generated/phase3_fixtures.jsonl}"
+VAL_FILE="${VAL_FILE:-$TRAIN_FILE}"
+TOOL_CONFIG="${TOOL_CONFIG:-$PROJECT_DIR/phase3_rl/generated/tool_config.yaml}"
+AGENT_LOOP_CONFIG="${AGENT_LOOP_CONFIG:-$PROJECT_DIR/phase3_rl/verl_agent_loop.yaml}"
+MODEL_PATH="${MODEL_PATH:-Qwen/Qwen2.5-0.5B-Instruct}"
+EXPERIMENT_NAME="${EXPERIMENT_NAME:-crayotter-phase3-grpo-smoke}"
+FIXTURES="${FIXTURES:-local_smoke}"
+TOOL_FIXTURE="${TOOL_FIXTURE:-local_smoke}"
+MAX_PROMPT_LENGTH="${MAX_PROMPT_LENGTH:-16384}"
+MAX_RESPONSE_LENGTH="${MAX_RESPONSE_LENGTH:-1536}"
+REGENERATE_ASSETS="${REGENERATE_ASSETS:-1}"
+TRAIN_BATCH_SIZE="${TRAIN_BATCH_SIZE:-1}"
+PPO_MINI_BATCH_SIZE="${PPO_MINI_BATCH_SIZE:-1}"
+PPO_MICRO_BATCH_SIZE="${PPO_MICRO_BATCH_SIZE:-1}"
+ROLLOUT_N="${ROLLOUT_N:-4}"
+LOGPROB_MICRO_BATCH_SIZE="${LOGPROB_MICRO_BATCH_SIZE:-1}"
+VAL_BATCH_SIZE="${VAL_BATCH_SIZE:-1}"
+ATTN_IMPLEMENTATION="${ATTN_IMPLEMENTATION:-sdpa}"
+MODEL_DTYPE="${MODEL_DTYPE:-bfloat16}"
+ROLLOUT_DTYPE="${ROLLOUT_DTYPE:-bfloat16}"
+ROLLOUT_ENFORCE_EAGER="${ROLLOUT_ENFORCE_EAGER:-True}"
+ROLLOUT_MAX_NUM_SEQS="${ROLLOUT_MAX_NUM_SEQS:-32}"
+SGLANG_ATTENTION_BACKEND="${SGLANG_ATTENTION_BACKEND:-triton}"
+SGLANG_MM_ATTENTION_BACKEND="${SGLANG_MM_ATTENTION_BACKEND:-triton_attn}"
+SGLANG_SAMPLING_BACKEND="${SGLANG_SAMPLING_BACKEND:-pytorch}"
+AGENT_LOOP_WORKERS="${AGENT_LOOP_WORKERS:-1}"
+USE_REMOVE_PADDING="${USE_REMOVE_PADDING:-False}"
+
+if [[ "$REGENERATE_ASSETS" == "1" ]] || [[ ! -f "$TRAIN_FILE" ]]; then
+  python3 -m phase3_rl.export_verl_phase3_dataset --fixtures $FIXTURES --output "$TRAIN_FILE"
+fi
+
+if [[ "$REGENERATE_ASSETS" == "1" ]] || [[ ! -f "$TOOL_CONFIG" ]]; then
+  python3 -m phase3_rl.generate_verl_tool_config --fixture "$TOOL_FIXTURE" --output "$TOOL_CONFIG"
+fi
+
+if [[ ! -d "$RUN_CWD/verl/trainer/config" ]]; then
+  echo "Expected Hydra config root at: $RUN_CWD/verl/trainer/config"
+  echo "Set RUN_CWD or VERL_DIR to a valid verl repo root before running this script."
+  exit 1
+fi
+
+# Prefer the vendored verl checkout over any separately installed copy so
+# the trainer module and Hydra configs stay in sync.
+export PYTHONPATH="$VERL_DIR:$PROJECT_DIR:${PYTHONPATH:-}"
+
+# Some environments propagate a non-numeric OMP_NUM_THREADS, which libgomp
+# rejects before training starts.
+if [[ -n "${OMP_NUM_THREADS:-}" ]] && ! [[ "${OMP_NUM_THREADS}" =~ ^[0-9]+$ ]]; then
+  export OMP_NUM_THREADS=1
+fi
+
+cd "$RUN_CWD"
+
+python3 -m verl.trainer.main_ppo \
+  --config-path="$CONFIG_PATH" \
+  --config-name='gsm8k_multiturn_grpo' \
+  algorithm.adv_estimator=grpo \
+  data.train_files="$TRAIN_FILE" \
+  data.val_files="$VAL_FILE" \
+  data.train_batch_size="$TRAIN_BATCH_SIZE" \
+  data.val_batch_size="$VAL_BATCH_SIZE" \
+  data.max_prompt_length="$MAX_PROMPT_LENGTH" \
+  data.max_response_length="$MAX_RESPONSE_LENGTH" \
+  data.filter_overlong_prompts=True \
+  data.truncation='error' \
+  data.return_raw_chat=True \
+  actor_rollout_ref.model.path="$MODEL_PATH" \
+  +actor_rollout_ref.model.override_config.attn_implementation="$ATTN_IMPLEMENTATION" \
+  actor_rollout_ref.model.use_remove_padding="$USE_REMOVE_PADDING" \
+  actor_rollout_ref.model.enable_gradient_checkpointing=True \
+  actor_rollout_ref.actor.optim.lr=1e-6 \
+  actor_rollout_ref.actor.ppo_mini_batch_size="$PPO_MINI_BATCH_SIZE" \
+  actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu="$PPO_MICRO_BATCH_SIZE" \
+  actor_rollout_ref.actor.use_kl_loss=True \
+  actor_rollout_ref.actor.kl_loss_coef=0.001 \
+  actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+  actor_rollout_ref.actor.entropy_coeff=0 \
+  actor_rollout_ref.actor.fsdp_config.param_offload=False \
+  actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+  actor_rollout_ref.actor.fsdp_config.model_dtype="$MODEL_DTYPE" \
+  actor_rollout_ref.actor.fsdp_config.dtype="$MODEL_DTYPE" \
+  actor_rollout_ref.rollout.name=sglang \
+  actor_rollout_ref.rollout.mode=async \
+  actor_rollout_ref.rollout.dtype="$ROLLOUT_DTYPE" \
+  actor_rollout_ref.rollout.enforce_eager="$ROLLOUT_ENFORCE_EAGER" \
+  actor_rollout_ref.rollout.max_num_seqs="$ROLLOUT_MAX_NUM_SEQS" \
+  actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+  actor_rollout_ref.rollout.gpu_memory_utilization=0.55 \
+  actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu="$LOGPROB_MICRO_BATCH_SIZE" \
+  actor_rollout_ref.rollout.n="$ROLLOUT_N" \
+  +actor_rollout_ref.rollout.engine_kwargs.sglang.attention_backend="$SGLANG_ATTENTION_BACKEND" \
+  +actor_rollout_ref.rollout.engine_kwargs.sglang.mm_attention_backend="$SGLANG_MM_ATTENTION_BACKEND" \
+  +actor_rollout_ref.rollout.engine_kwargs.sglang.sampling_backend="$SGLANG_SAMPLING_BACKEND" \
+  actor_rollout_ref.rollout.multi_turn.enable=True \
+  actor_rollout_ref.rollout.multi_turn.max_assistant_turns=8 \
+  actor_rollout_ref.rollout.multi_turn.max_parallel_calls=1 \
+  actor_rollout_ref.rollout.multi_turn.tool_config_path="$TOOL_CONFIG" \
+  actor_rollout_ref.rollout.agent.num_workers="$AGENT_LOOP_WORKERS" \
+  actor_rollout_ref.rollout.agent.default_agent_loop=crayotter_phase3_tool_agent \
+  actor_rollout_ref.rollout.agent.agent_loop_config_path="$AGENT_LOOP_CONFIG" \
+  actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu="$LOGPROB_MICRO_BATCH_SIZE" \
+  actor_rollout_ref.ref.fsdp_config.param_offload=True \
+  actor_rollout_ref.ref.fsdp_config.model_dtype="$MODEL_DTYPE" \
+  actor_rollout_ref.ref.fsdp_config.dtype="$MODEL_DTYPE" \
+  algorithm.use_kl_in_reward=False \
+  trainer.logger='["console"]' \
+  trainer.project_name='crayotter-phase3-rl' \
+  trainer.experiment_name="$EXPERIMENT_NAME" \
+  trainer.n_gpus_per_node=1 \
+  trainer.nnodes=1 \
+  trainer.total_training_steps=10 \
+  trainer.test_freq=5 \
+  trainer.save_freq=5 \
+  trainer.critic_warmup=0 \
+  "$@"

--- a/phase3_rl/tool_catalog.py
+++ b/phase3_rl/tool_catalog.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.utils.function_calling import convert_to_openai_tool
+
+from script import graph as graph_module
+from script import tools as tools_module
+
+
+def get_tool_map() -> dict[str, Any]:
+    return {getattr(tool, "name", ""): tool for tool in tools_module.ALL_TOOLS}
+
+
+def get_phase3_tool_names() -> list[str]:
+    return sorted(graph_module.EDITING_TOOL_NAMES)
+
+
+def get_tools_by_name(tool_names: list[str]) -> list[Any]:
+    tool_map = get_tool_map()
+    missing = [name for name in tool_names if name not in tool_map]
+    if missing:
+        raise KeyError(f"Unknown tools requested: {missing}")
+    return [tool_map[name] for name in tool_names]
+
+
+def get_openai_tool_schemas(tool_names: list[str]) -> list[dict[str, Any]]:
+    return [convert_to_openai_tool(tool) for tool in get_tools_by_name(tool_names)]

--- a/phase3_rl/tool_runner.py
+++ b/phase3_rl/tool_runner.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from .tool_runtime import RESULT_SENTINEL, parse_tool_result_text
+
+
+def _emit(payload: dict) -> None:
+    print(f"{RESULT_SENTINEL}{json.dumps(payload, ensure_ascii=False)}")
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+        runtime_root = str(payload["runtime_root"])
+        tool_name = str(payload["tool_name"])
+        arguments = dict(payload.get("arguments", {}))
+        api_config = dict(payload.get("api_config", {}))
+    except Exception as exc:
+        _emit(
+            {
+                "raw_result": f"Invalid runner payload: {exc}",
+                "parsed_result": "",
+                "success": False,
+                "output_paths": [],
+                "duration_seconds": None,
+            }
+        )
+        return 1
+
+    os.environ["CRAYOTTER_RUNTIME_ROOT"] = runtime_root
+    project_root = Path(__file__).resolve().parents[1]
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+    try:
+        from app.runtime_paths import configure_runtime_environment
+        from script import tools as tools_module
+    except Exception as exc:
+        _emit(
+            {
+                "raw_result": f"Tool import failed: {exc}",
+                "parsed_result": "",
+                "success": False,
+                "output_paths": [],
+                "duration_seconds": None,
+            }
+        )
+        return 1
+
+    configure_runtime_environment()
+    tools_module.configure(**{key: value for key, value in api_config.items() if value is not None})
+    tool_map = {getattr(tool, "name", ""): tool for tool in tools_module.ALL_TOOLS}
+    if tool_name not in tool_map:
+        _emit(
+            {
+                "raw_result": f"Unknown tool: {tool_name}",
+                "parsed_result": "",
+                "success": False,
+                "output_paths": [],
+                "duration_seconds": None,
+            }
+        )
+        return 1
+
+    tool = tool_map[tool_name]
+    try:
+        raw_result = tool.invoke(arguments)
+        parsed_result, success, output_paths, duration_seconds = parse_tool_result_text(raw_result, runtime_root)
+        _emit(
+            {
+                "raw_result": raw_result,
+                "parsed_result": parsed_result,
+                "success": success,
+                "output_paths": output_paths,
+                "duration_seconds": duration_seconds,
+            }
+        )
+        return 0 if success else 2
+    except Exception as exc:
+        _emit(
+            {
+                "raw_result": f"{tool_name} execution failed: {exc}",
+                "parsed_result": "",
+                "success": False,
+                "output_paths": [],
+                "duration_seconds": None,
+            }
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/phase3_rl/tool_runtime.py
+++ b/phase3_rl/tool_runtime.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+KNOWN_ERROR_MARKERS = (
+    "出错",
+    "失败",
+    "异常",
+    "error",
+    "exception",
+    "traceback",
+)
+
+RESULT_SENTINEL = "__PHASE3_RL_RESULT__"
+
+
+@dataclass(slots=True)
+class ToolExecutionResult:
+    tool_name: str
+    arguments: dict[str, Any]
+    raw_result: str
+    parsed_result: Any
+    success: bool
+    returncode: int
+    stdout: str
+    stderr: str
+    output_paths: list[str] = field(default_factory=list)
+    duration_seconds: float | None = None
+
+
+def load_api_config_from_env() -> dict[str, str]:
+    env = os.environ
+    return {
+        "api_key": env.get("CRAYOTTER_API_KEY") or env.get("OPENAI_API_KEY", ""),
+        "base_url": env.get("CRAYOTTER_BASE_URL", ""),
+        "model_name": env.get("CRAYOTTER_MODEL_NAME", ""),
+        "video_api_key": env.get("CRAYOTTER_VIDEO_API_KEY", ""),
+        "video_base_url": env.get("CRAYOTTER_VIDEO_BASE_URL", ""),
+        "video_model_name": env.get("CRAYOTTER_VIDEO_MODEL_NAME", ""),
+        "tts_api_key": env.get("CRAYOTTER_TTS_API_KEY", ""),
+        "tts_base_url": env.get("CRAYOTTER_TTS_BASE_URL", ""),
+        "tts_model_name": env.get("CRAYOTTER_TTS_MODEL_NAME", ""),
+    }
+
+
+def _strip_fenced_json(text: str) -> str:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        parts = stripped.split("```")
+        if len(parts) >= 3:
+            return parts[1].split("\n", 1)[-1].strip()
+    return stripped
+
+
+def _looks_like_error(text: str) -> bool:
+    lowered = text.lower()
+    return any(marker in lowered for marker in KNOWN_ERROR_MARKERS)
+
+
+def _collect_paths(value: Any, runtime_root: Path, collector: set[str]) -> None:
+    if isinstance(value, dict):
+        for item in value.values():
+            _collect_paths(item, runtime_root, collector)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _collect_paths(item, runtime_root, collector)
+        return
+    if not isinstance(value, str):
+        return
+
+    candidate = value.strip()
+    if not candidate:
+        return
+    path = Path(candidate)
+    if not path.is_absolute():
+        path = (runtime_root / candidate).resolve(strict=False)
+    else:
+        path = path.resolve(strict=False)
+    if path.exists():
+        collector.add(str(path))
+
+
+def parse_tool_result_text(raw_result: str, runtime_root: str | Path) -> tuple[Any, bool, list[str], float | None]:
+    text = _strip_fenced_json(str(raw_result or ""))
+    parsed: Any = text
+    success = not _looks_like_error(text)
+    output_paths: set[str] = set()
+    duration_seconds: float | None = None
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        parsed = text
+    else:
+        if isinstance(parsed, dict):
+            status = str(parsed.get("status", "")).strip().lower()
+            if status:
+                success = status == "success"
+            dur = parsed.get("duration")
+            if dur is None:
+                dur = parsed.get("duration_seconds")
+            if isinstance(dur, (int, float)):
+                duration_seconds = float(dur)
+        elif isinstance(parsed, list):
+            success = True
+
+    _collect_paths(parsed, Path(runtime_root).resolve(), output_paths)
+    return parsed, success, sorted(output_paths), duration_seconds
+
+
+def execute_tool_subprocess(
+    *,
+    tool_name: str,
+    arguments: dict[str, Any],
+    runtime_root: str | Path,
+    api_config: dict[str, str] | None = None,
+    python_executable: str | None = None,
+    timeout_seconds: int = 900,
+) -> ToolExecutionResult:
+    payload = {
+        "tool_name": tool_name,
+        "arguments": arguments,
+        "runtime_root": str(Path(runtime_root).resolve()),
+        "api_config": api_config or {},
+    }
+
+    process = subprocess.run(
+        [python_executable or sys.executable, "-m", "phase3_rl.tool_runner"],
+        input=json.dumps(payload, ensure_ascii=False),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout_seconds,
+        cwd=str(Path(__file__).resolve().parents[1]),
+    )
+
+    stdout = process.stdout or ""
+    stderr = process.stderr or ""
+    result_line = ""
+    for line in stdout.splitlines()[::-1]:
+        if line.startswith(RESULT_SENTINEL):
+            result_line = line[len(RESULT_SENTINEL) :].strip()
+            break
+    if not result_line:
+        result_line = json.dumps(
+            {
+                "raw_result": f"Tool subprocess did not return structured payload for {tool_name}.",
+                "success": False,
+                "parsed_result": "",
+                "output_paths": [],
+                "duration_seconds": None,
+            },
+            ensure_ascii=False,
+        )
+
+    runner_payload = json.loads(result_line)
+    parsed_result = runner_payload.get("parsed_result")
+    success = bool(runner_payload.get("success", False)) and process.returncode == 0
+    raw_result = str(runner_payload.get("raw_result", ""))
+    output_paths = [str(item) for item in runner_payload.get("output_paths", [])]
+    duration_seconds = runner_payload.get("duration_seconds")
+    if isinstance(duration_seconds, (int, float)):
+        duration_seconds = float(duration_seconds)
+    else:
+        duration_seconds = None
+
+    return ToolExecutionResult(
+        tool_name=tool_name,
+        arguments=arguments,
+        raw_result=raw_result,
+        parsed_result=parsed_result,
+        success=success,
+        returncode=process.returncode,
+        stdout=stdout,
+        stderr=stderr,
+        output_paths=output_paths,
+        duration_seconds=duration_seconds,
+    )

--- a/phase3_rl/verl_agent_loop.py
+++ b/phase3_rl/verl_agent_loop.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .reward import compute_episode_reward
+
+try:
+    from verl.experimental.agent_loop.agent_loop import register
+    from verl.experimental.agent_loop.tool_agent_loop import ToolAgentLoop
+except Exception as exc:  # pragma: no cover - optional dependency
+    ToolAgentLoop = None
+    register = None
+    _VERL_IMPORT_ERROR = exc
+else:
+    _VERL_IMPORT_ERROR = None
+
+
+if ToolAgentLoop is not None and register is not None:
+
+    @register("crayotter_phase3_tool_agent")
+    class CrayotterPhase3ToolAgentLoop(ToolAgentLoop):
+        """verl AgentLoop adapter for Crayotter Phase 3."""
+
+        async def run(self, sampling_params: dict[str, Any], **kwargs):
+            output = await super().run(sampling_params, **kwargs)
+            tool_events = list(output.extra_fields.get("phase3_tool_trace", []))
+            target_duration = float(
+                output.extra_fields.get(
+                    "phase3_target_duration_seconds",
+                    kwargs.get("target_duration_seconds", 0.0),
+                )
+                or 0.0
+            )
+            reward_summary = compute_episode_reward(
+                tool_events=tool_events,
+                target_duration_seconds=target_duration,
+                final_output="completed" if output.response_ids else "",
+            )
+            output.reward_score = reward_summary["total_reward"]
+            output.extra_fields["phase3_episode_reward"] = reward_summary
+            return output
+
+else:
+
+    class CrayotterPhase3ToolAgentLoop:  # pragma: no cover
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "verl is required to instantiate CrayotterPhase3ToolAgentLoop. "
+                f"Original import error: {_VERL_IMPORT_ERROR}"
+            )

--- a/phase3_rl/verl_agent_loop.yaml
+++ b/phase3_rl/verl_agent_loop.yaml
@@ -1,0 +1,2 @@
+- name: crayotter_phase3_tool_agent
+  _target_: phase3_rl.verl_agent_loop.CrayotterPhase3ToolAgentLoop

--- a/phase3_rl/verl_tools.py
+++ b/phase3_rl/verl_tools.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from .fixture import load_fixture, materialize_fixture
+from .reward import compute_step_reward
+from .tool_runtime import execute_tool_subprocess, load_api_config_from_env
+
+try:
+    from verl.tools.base_tool import BaseTool
+    from verl.tools.schemas import OpenAIFunctionToolSchema, ToolResponse
+except Exception as exc:  # pragma: no cover - optional dependency
+    BaseTool = None
+    OpenAIFunctionToolSchema = Any
+    ToolResponse = Any
+    _VERL_IMPORT_ERROR = exc
+else:
+    _VERL_IMPORT_ERROR = None
+
+
+if BaseTool is not None:
+
+    class CrayotterSubprocessTool(BaseTool):
+        """Wrap a Crayotter Phase 3 tool as a verl native tool."""
+
+        def __init__(self, config: dict, tool_schema: OpenAIFunctionToolSchema):
+            super().__init__(config, tool_schema)
+            self.tool_name = str(config.get("tool_name") or self.name)
+            self._instance_kwargs: dict[str, dict[str, Any]] = {}
+
+        async def create(self, instance_id: str | None = None, **kwargs):
+            instance_id = instance_id or uuid4().hex
+            self._instance_kwargs[instance_id] = dict(kwargs.get("create_kwargs", {}))
+            return instance_id, ToolResponse(text="")
+
+        async def execute(self, instance_id: str, parameters: dict[str, Any], **kwargs):
+            create_kwargs = self._instance_kwargs.get(instance_id, {})
+            fixture_path = str(create_kwargs.get("fixture_path", "")).strip()
+            if not fixture_path:
+                return ToolResponse(text="Missing fixture_path in create_kwargs."), -0.5, {"success": False}
+
+            episode_base_dir = Path(str(create_kwargs.get("episode_base_dir", Path("phase3_rl/runs/verl")))).resolve()
+            agent_data = kwargs.get("agent_data")
+            if agent_data is not None:
+                state = agent_data.extra_fields.get("phase3_episode_state")
+                if not state:
+                    fixture = load_fixture(fixture_path)
+                    episode_root = episode_base_dir / f"{fixture.fixture_id}_{agent_data.request_id}"
+                    materialize_fixture(fixture, episode_root)
+                    state = {
+                        "fixture_id": fixture.fixture_id,
+                        "fixture_path": fixture_path,
+                        "episode_root": str(episode_root),
+                        "tool_events": [],
+                    }
+                    agent_data.extra_fields["phase3_episode_state"] = state
+                    agent_data.extra_fields["phase3_target_duration_seconds"] = fixture.target_duration_seconds
+                episode_root = Path(state["episode_root"])
+                prior_events = list(state.get("tool_events", []))
+            else:  # pragma: no cover
+                fixture = load_fixture(fixture_path)
+                episode_root = episode_base_dir / f"{fixture.fixture_id}_{uuid4().hex[:8]}"
+                materialize_fixture(fixture, episode_root)
+                prior_events = []
+
+            execution = execute_tool_subprocess(
+                tool_name=self.tool_name,
+                arguments=parameters,
+                runtime_root=episode_root,
+                api_config=load_api_config_from_env(),
+            )
+
+            reward = compute_step_reward(tool_name=self.tool_name, execution=execution, prior_events=prior_events)
+            event = {
+                "tool_name": self.tool_name,
+                "arguments": parameters,
+                "success": execution.success,
+                "raw_result": execution.raw_result,
+                "parsed_result": execution.parsed_result,
+                "output_paths": execution.output_paths,
+                "duration_seconds": execution.duration_seconds,
+                "step_reward": reward.total,
+                "step_reward_components": reward.components,
+                "signature": f"{self.tool_name}:{parameters}",
+            }
+
+            if agent_data is not None:
+                state = agent_data.extra_fields["phase3_episode_state"]
+                state.setdefault("tool_events", []).append(event)
+                agent_data.extra_fields["phase3_tool_trace"] = list(state["tool_events"])
+                agent_data.extra_fields["phase3_episode_root"] = str(episode_root)
+
+            return ToolResponse(text=execution.raw_result), reward.total, {"success": execution.success}
+
+        async def release(self, instance_id: str, **kwargs) -> None:
+            self._instance_kwargs.pop(instance_id, None)
+
+else:
+
+    class CrayotterSubprocessTool:  # pragma: no cover
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "verl is required to instantiate CrayotterSubprocessTool. "
+                f"Original import error: {_VERL_IMPORT_ERROR}"
+            )


### PR DESCRIPTION
## What

- add `phase3_rl` scaffold for the current `verl + Qwen3.5 + Crayotter` Phase 3 RL smoke pipeline
- add local smoke fixture, dataset export, tool-config export, and GRPO smoke launcher
- add English and Chinese README for setup and reproduction

## Notes

- this PR focuses on the `phase3_rl` integration code and documentation
- runtime artifacts such as `runs/`, `generated/`, logs, and temp files are intentionally excluded
- the current smoke path was validated on a single-GPU(RTX4090) AutoDL environment
- this PR does not vendor `_vendor/verl` into `idwts/Crayotter`; the validated smoke path currently depends on a separate vendored and locally patched `verl` checkout

## Local `verl` patch summary

The current smoke path was validated against a vendored `verl` checkout with a small local patch set, mainly for Qwen3.5 multimodal position handling and environment compatibility:

- normalize Qwen3.5 3D mRoPE `position_ids` to the canonical `(4, batch, seq)` layout before model forward
- add helpers to pad nested / jagged 3D multimodal `position_ids` into dense tensors
- update automodel / fsdp / torchtitan transformer paths to use the new mRoPE padding logic
- fix TensorDict index-select and no-padding conversion for 3D nested `position_ids`, and add a regression test
- make the PPO trainer entropy path conditional instead of assuming entropy is always present
- add a safer fallback when `flash_attn.bert_padding` is unavailable
- update the vendored `verl` sglang requirements baseline:
  - `sglang[all]==0.5.9`
  - `transformers==5.5.3`
  - `huggingface_hub==1.10.1`

These `verl` patches are not included in this PR yet; they are documented here because the current smoke path depends on them.
